### PR TITLE
Test transformers for targeting browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Don’t commit the following files and directories created by pub, Dart Editor, and dart2js
 **/packages
+.packages
 .project
 .buildlog
 .idea

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -215,9 +215,9 @@ class StaticMapperGenerator extends Transformer with ResolverTransformer {
       if (fields.isNotEmpty) {
         var key = usedLibs.resolveLib(clazz.library);
         if (key.isNotEmpty) {
-          key = "$key.$clazz";
+          key = "$key.${clazz.displayName}";
         } else {
-          key = "$clazz";
+          key = "${clazz.displayName}";
         }
         types[key] =
             new _TypeCodecGenerator(collectionType, usedLibs, key, fields);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,3 +17,5 @@ dev_dependencies:
   test: "^0.12.6"
 transformers:
   - redstone_mapper
+  - test/pub_serve:
+      $include: test/client_test.dart

--- a/test/src/domain.dart
+++ b/test/src/domain.dart
@@ -152,12 +152,17 @@ TestComplexObj createComplexObj() {
   return obj;
 }
 
-abstract class Identifiable {
+class Dummy {
+  @Field()
+  num dummy;
+}
+
+class Identifiable {
   @Field()
   String id;
 }
 
-abstract class Nameable {
+class Nameable {
   @Field()
   String username;
 
@@ -165,7 +170,7 @@ abstract class Nameable {
   String password;
 }
 
-class MixedUser extends Object with Identifiable, Nameable {
+class MixedUser extends Dummy with Identifiable, Nameable {
   @override
   toString() => '''
     id:       $id


### PR DESCRIPTION
After trying following commands in order to test browser target, I found issue on type creation. 
```
$ pub serve
$ pub run test --pub-serve=8080 -p chrome
```

Then, current travis-ci.yml file only targets server mode.
How to define tests to target browser mode as well ?

Finally, there is still an issue (only with static mapper), but it's quite difficult to test transformers.
Do you have some procedure to debug when pub serve is running ?
```
00:04 +4 -1: test/client_test.dart: Encode: Mixin                                                  
  Expected: {'id': 'me', 'username': 'Alice', 'password': 'thereisnone'}
    Actual: {}
     Which: has different length and is missing map key 'id'
  
  package:test                expect
  src/common_tests.dart 65:7  installCommonTests.<fn>.<fn>
  
00:05 +9 -2: test/client_test.dart: Decode: Mixin                                                  
  Expected: '    id:       me\n'
    '    username: Alice\n'
    '    password: thereisnone'
    Actual: '    id:       null\n'
    '    username: null\n'
    '    password: null'
     Which: is different.
  Expected: ... id:       me\n    us ...
    Actual: ... id:       null\n     ...
                          ^
   Differ at offset 14
  
  package:test                 expect
  src/common_tests.dart 156:7  installCommonTests.<fn>.<fn>
  
00:05 +12 -2: Some tests failed.
```