### PR TITLE
Fixes issue that produces incomprehensible classnames.

### DIFF
--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -211,13 +211,15 @@ class StaticMapperGenerator extends Transformer with ResolverTransformer {
         .where((p) => !p.isStatic && !p.isPrivate)
         .forEach((p) => _scannAccessor(fields, p, accessorIdxs));
 
+    var className = "$clazz".replaceFirst(new RegExp(r'(abstract )?class '), '');
+
     if (rootType) {
       if (fields.isNotEmpty) {
         var key = usedLibs.resolveLib(clazz.library);
         if (key.isNotEmpty) {
-          key = "$key.$clazz";
+          key = "$key.$className";
         } else {
-          key = "$clazz";
+          key = "$className";
         }
         types[key] =
             new _TypeCodecGenerator(collectionType, usedLibs, key, fields);


### PR DESCRIPTION
I was having issues where the transformer generated code that couldn't be parsed because the type names included the keyword class.